### PR TITLE
Add note about quotes with open-remote-ssh extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ does not exist).
 ```
 Host <YOUR-JUPYTERHUB-DOMAIN>
     User <YOUR-JUPYTERHUB-CONTAINER-USER-NAME>
-    ProxyCommand websocat --binary -H='Authorization: token <YOUR-JUPYTERHUB-TOKEN>' asyncstdio: wss://%h/user/<YOUR-JUPYTERHUB-USERNAME>/sshd/
+    ProxyCommand websocat --binary -H="Authorization: token <YOUR-JUPYTERHUB-TOKEN>" asyncstdio: wss://%h/user/<YOUR-JUPYTERHUB-USERNAME>/sshd/
 ```
 
 replace:
@@ -75,8 +75,13 @@ Here's an example:
 ```
 Host hub.openveda.cloud
     User jovyan
-    ProxyCommand websocat --binary -H='Authorization: token a56ff59c93f64fb587f46b06af9422ee' asyncstdio: wss://%h/user/yuvipanda/sshd/
+    ProxyCommand websocat --binary -H="Authorization: token a56ff59c93f64fb587f46b06af9422ee" asyncstdio: wss://%h/user/yuvipanda/sshd/
 ```
+
+*Note that if you are connecting to your JupyterHub in a VSCode fork that uses the 
+[open-remote-ssh](https://github.com/jeanp413/open-remote-ssh) extension, such as VSCodium, Cursor, or Positron,
+you need to make sure the value of the -H argument (`"Authorization: token xxxx"`) is enclosed in double 
+quotes and not single quotes, or the connection will fail.*
 
 We're almost there!
 


### PR DESCRIPTION
Through experimentation, I learned that when using this via a VSCode fork that uses the [open-remote-ssh](https://github.com/jeanp413/open-remote-ssh?tab=readme-ov-file) extension, it fails unless you use double quotes around the `-H` argument. This updates the README to use double quotes for Authorization token in ProxyCommand when in an IDE that uses the `open-remote-ssh` extension.

Closes #10